### PR TITLE
Fix: java.io.IOException: too many bytes to write to stream error

### DIFF
--- a/src/main/java/dev/f2a/addon/skriptwebapi/elements/server/effects/EffSendHttpResponse.java
+++ b/src/main/java/dev/f2a/addon/skriptwebapi/elements/server/effects/EffSendHttpResponse.java
@@ -54,7 +54,8 @@ public class EffSendHttpResponse extends Effect {
         }
 
         try {
-            exchange.sendResponseHeaders(code, body.length());
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(code, bytes.length);
             exchange.getResponseBody().write(body.getBytes(StandardCharsets.UTF_8));
             exchange.close();
         } catch (IOException ex) {


### PR DESCRIPTION
## Fixed:
* Exception "java.io.IOException: too many bytes to write to stream error" when sending response in http request with UTF-8 characer lager than U+0080.


Closes #12 